### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -1,4 +1,4 @@
-use bn::{Fr, Group, G1, AffineG1, Fq};
+use bn::{Fr, G1, AffineG1, Fq};
 use core::ops::{Add, Mul, Sub};
 
 use crate::public::*;
@@ -10,32 +10,34 @@ pub struct Ciphertext {
     pub points: (G1, G1),
 }
 
+type PointStr = (String, String);
+
 impl Ciphertext {
     /// Get the points of the ciphertext
     pub fn get_points(self) -> (G1, G1) {
-        return (self.points.0, self.points.1);
+        (self.points.0, self.points.1)
     }
 
     /// Get the points of the ciphertext as hexadecimal strings. It returns in the form
     /// `((x_point_1, y_point_1), (x_point_2, y_point_2))`
-    pub fn get_points_hex_string(self) -> Result<((String, String), (String, String)), ConversionError> {
+    pub fn get_points_hex_string(self) -> Result<(PointStr, PointStr), ConversionError> {
         let (point_1, point_2) = self.get_points();
 
         let point_1_hex = get_point_as_hex_str(point_1)?;
 
         let point_2_hex = get_point_as_hex_str(point_2)?;
 
-        return Ok((
+        Ok((
             point_1_hex, point_2_hex
             ))
     }
 
     /// Convert hexadecimal points to Ciphertext
-    pub fn from_hex_string((point1, point2): ((String, String), (String, String)), pk: PublicKey)
+    pub fn from_hex_string((point1, point2): (PointStr, PointStr), pk: PublicKey)
         -> Result<Self, ConversionError> {
 
-        if point1.0[0..2].to_owned() != "0x" || point1.1[0..2].to_owned() != "0x" ||
-            point2.0[0..2].to_owned() != "0x" || point2.1[0..2].to_owned() != "0x"
+        if &point1.0[0..2] != "0x" || &point1.1[0..2] != "0x" ||
+            &point2.0[0..2] != "0x" || &point2.1[0..2] != "0x"
         {
             return Err(ConversionError::IncorrectHexString);
         }
@@ -52,11 +54,11 @@ impl Ciphertext {
 
         let point2: G1 = from_hex(&point2_hex)?;
 
-        Ok(Ciphertext{pk: pk, points: (point1, point2)})
+        Ok(Ciphertext{pk, points: (point1, point2)})
     }
 
     /// Convert decimal string points to Ciphertext
-    pub fn from_dec_string((point1, point2): ((String, String), (String, String)), pk: PublicKey)
+    pub fn from_dec_string((point1, point2): (PointStr, PointStr), pk: PublicKey)
                            -> Result<Self, ConversionError> {
 
         let point_1_x = Fq::from_str(&point1.0);
@@ -75,7 +77,7 @@ impl Ciphertext {
         )?;
 
         Ok(Ciphertext{
-            pk: pk,
+            pk,
             points: (
                 G1::from(affine_point_1),
                 G1::from(affine_point_2)
@@ -184,6 +186,7 @@ impl Mul<Fr> for Ciphertext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bn::Group;
     use crate::private::SecretKey;
     use rand::thread_rng;
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -68,7 +68,7 @@ pub enum ProofError {
 
 impl From<ConversionError> for ProofError {
     fn from (_e: ConversionError) -> ProofError {
-        return ProofError::ConversionVerificationError
+        ProofError::ConversionVerificationError
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,7 +1,6 @@
 #![allow(non_snake_case)]
 use rand::{thread_rng, Rng};
 
-use bincode;
 use bincode::rustc_serialize::encode;
 use bincode::SizeLimit::Infinite;
 use sha3::{Digest, Keccak256};
@@ -92,7 +91,7 @@ impl SecretKey {
         ciphertext: &Ciphertext,
         message: &G1
     ) -> Result<[String; 7], ConversionError> {
-        let message_str = get_point_as_hex_str(message.clone())?;
+        let message_str = get_point_as_hex_str(*message)?;
         let proof = match self.prove_correct_decryption_no_Merlin(&ciphertext, &message) {
             Ok(proof) => proof,
             Err(e) => return Err(e)
@@ -130,7 +129,7 @@ impl<'a> From<&'a SecretKey> for PublicKey {
 }
 
 fn jacobian_to_affine(point: &G1) -> Result<AffineG1, ConversionError> {
-    AffineG1::from_jacobian(point.clone())
+    AffineG1::from_jacobian(*point)
         .ok_or(ConversionError::AffineConversionFailure)
 }
 

--- a/src/public.rs
+++ b/src/public.rs
@@ -120,7 +120,7 @@ impl PublicKey {
     ) -> Result<(), ProofError> {
         let ((announcement_base_G, announcement_base_ctxtp0), response) = proof;
 
-        let message_affine = AffineG1::from_jacobian(message.clone()).ok_or(ConversionError::AffineConversionFailure)?;
+        let message_affine = AffineG1::from_jacobian(message).ok_or(ConversionError::AffineConversionFailure)?;
         let ctx1_affine = AffineG1::from_jacobian(ciphertext.points.0).ok_or(ConversionError::AffineConversionFailure)?;
         let ctx2_affine = AffineG1::from_jacobian(ciphertext.points.1).ok_or(ConversionError::AffineConversionFailure)?;
         let announcement_g_affine = AffineG1::from_jacobian(announcement_base_G).ok_or(ConversionError::AffineConversionFailure)?;
@@ -149,7 +149,7 @@ impl PublicKey {
     }
 
     pub fn from_hex_string(hex_coords: (String, String)) -> Result<Self, ConversionError> {
-        if hex_coords.0[0..2].to_owned() != "0x" || hex_coords.1[0..2].to_owned() != "0x" {
+        if &hex_coords.0[0..2] != "0x" || &hex_coords.1[0..2] != "0x" {
             return Err(ConversionError::IncorrectHexString);
         }
 
@@ -160,7 +160,7 @@ impl PublicKey {
         let combined_string = "04".to_owned() + &hex_coords.0[2..] + &hex_coords.1[2..];
         let pk_point: G1 = match from_hex(&combined_string) {
             Ok(point) => point,
-            Err(e) => return Err(ConversionError::from(e)),
+            Err(e) => return Err(e),
         };
         Ok(PublicKey::from(pk_point))
     }


### PR DESCRIPTION
Removes a few copies and allows `cargo clippy` to pass without warnings