### PR TITLE
Remove hex string conversions

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,7 +1,5 @@
 extern crate sha3;
-extern crate rustc_hex;
-use bn::{G1, Group, };
-use elgamal_bn::public::{get_scalar_as_hex_str, get_point_as_hex_str, };
+use bn::{G1, Group};
 
 use rand::thread_rng;
 use elgamal_bn::private::SecretKey;
@@ -13,20 +11,9 @@ fn main() {
     let sk = SecretKey::new(&mut csprng);
     let pk = PublicKey::from(&sk);
 
-    println!("Public Key hexadecimal: {:?}", pk.get_point_hex_string().unwrap());
-
     let plaintext = G1::random(&mut csprng);
-    println!("Plaintext hexadecimal: {:?}", get_point_as_hex_str(plaintext).unwrap());
-
     let ciphertext = pk.encrypt(&plaintext);
-    println!("Ciphertext hexadecimal: {:?}", ciphertext.get_points_hex_string());
-
     let decryption = sk.decrypt(&ciphertext);
     let proof = sk.prove_correct_decryption_no_Merlin(&ciphertext, &decryption).unwrap();
-    println!("Generator times response: {:?}", get_point_as_hex_str(G1::one() * proof.1));
-    println!("Announcement G: {:?}", get_point_as_hex_str((proof.0).0));
-    println!("Announcement Ctxt: {:?}", get_point_as_hex_str((proof.0).1));
-    println!("Response: {:?}", get_scalar_as_hex_str(proof.1));
-
     assert!(pk.verify_correct_decryption_no_Merlin(proof, ciphertext, plaintext).is_ok());
 }

--- a/src/ciphertext.rs
+++ b/src/ciphertext.rs
@@ -18,45 +18,6 @@ impl Ciphertext {
         (self.points.0, self.points.1)
     }
 
-    /// Get the points of the ciphertext as hexadecimal strings. It returns in the form
-    /// `((x_point_1, y_point_1), (x_point_2, y_point_2))`
-    pub fn get_points_hex_string(self) -> Result<(PointStr, PointStr), ConversionError> {
-        let (point_1, point_2) = self.get_points();
-
-        let point_1_hex = get_point_as_hex_str(point_1)?;
-
-        let point_2_hex = get_point_as_hex_str(point_2)?;
-
-        Ok((
-            point_1_hex, point_2_hex
-            ))
-    }
-
-    /// Convert hexadecimal points to Ciphertext
-    pub fn from_hex_string((point1, point2): (PointStr, PointStr), pk: PublicKey)
-        -> Result<Self, ConversionError> {
-
-        if &point1.0[0..2] != "0x" || &point1.1[0..2] != "0x" ||
-            &point2.0[0..2] != "0x" || &point2.1[0..2] != "0x"
-        {
-            return Err(ConversionError::IncorrectHexString);
-        }
-
-        if point1.0.len() != 66 || point1.1.len() != 66 ||
-            point1.0.len() != 66 || point1.1.len() != 66
-        {
-            return Err(ConversionError::InvalidHexLength);
-        }
-
-        let point1_hex = "04".to_owned() + &point1.0[2..] + &point1.1[2..];
-        let point2_hex = "04".to_owned() + &point2.0[2..] + &point2.1[2..];
-        let point1: G1 = from_hex(&point1_hex)?;
-
-        let point2: G1 = from_hex(&point2_hex)?;
-
-        Ok(Ciphertext{pk, points: (point1, point2)})
-    }
-
     /// Convert decimal string points to Ciphertext
     pub fn from_dec_string((point1, point2): (PointStr, PointStr), pk: PublicKey)
                            -> Result<Self, ConversionError> {
@@ -273,18 +234,6 @@ mod tests {
 
         let check = mult_dec_pltxt == mult_pltxt;
         assert!(check);
-    }
-
-    #[test]
-    fn test_from_hex_conversion() {
-        let sk = SecretKey::new(&mut thread_rng());
-        let pk = PublicKey::from(&sk);
-        let ctxt = pk.encrypt(&G1::random(&mut thread_rng()));
-
-        let ctxt_hex = ctxt.get_points_hex_string().unwrap();
-        let ctxt_from_hex = Ciphertext::from_hex_string(ctxt_hex, pk).unwrap();
-
-        assert_eq!(ctxt_from_hex, ctxt)
     }
 
     #[test]

--- a/src/private.rs
+++ b/src/private.rs
@@ -83,21 +83,6 @@ impl SecretKey {
         let response = announcement_random + challenge * self.get_scalar();
         Ok(((announcement_base_G, announcement_base_ctxtp0), response))
     }
-
-    /// Return the proof announcement (Point1, Poin2) \in G^2 and response r \in Zp as hexadecimal
-    /// strings (a, b, c, d, e)
-    pub fn proof_decryption_as_string(
-        &self,
-        ciphertext: &Ciphertext,
-        message: &G1
-    ) -> Result<[String; 7], ConversionError> {
-        let message_str = get_point_as_hex_str(*message)?;
-        let (point, scalar) = self.prove_correct_decryption_no_Merlin(&ciphertext, &message)?;
-        let announcement_1 = get_point_as_hex_str(point.0)?;
-        let announcement_2 = get_point_as_hex_str(point.1)?;
-        let response = get_scalar_as_hex_str(scalar)?;
-        Ok([message_str.0, message_str.1, announcement_1.0, announcement_1.1, announcement_2.0, announcement_2.1, response])
-    }
 }
 
 impl From<Fr> for SecretKey {


### PR DESCRIPTION
The hex string conversion code depends on rustc-serialize, which is deprecated in favor of
serde and preventing a bincode upgrade.

Do you really need these functions? If so, close this PR and let's move these implementations to serde. If not, 🔪 